### PR TITLE
fix: pluralize field name when table name isn't plural

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -26,7 +26,7 @@ function transformModel(model: Model) {
 			const {name, kind, type, relationFromFields, relationToFields, isList} = draftField;
 
 			// Transform field name
-			draftField.name = isList ? camelcase(name) : camelcase(pluralize(name, 1));
+			draftField.name = isList ? camelcase(pluralize.plural(name)) : camelcase(pluralize.singular(name));
 
 			if (draftField.name !== name) {
 				draftField.columnName = name;


### PR DESCRIPTION
I think the current logic is that all tables are assumed to have plural form names?

This would handle the case where they don't (i.e. `CREATE TABLE "post"` vs `CREATE TABLE "posts"`).