### PR TITLE
feat: format enum default in camelCase

### DIFF
--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -97,7 +97,7 @@ function handleAttributes(attributes: Attribute, kind: DMMF.DatamodelFieldKind |
 			`@relation(name: "${relationName}")`;
 	}
 
-	if (kind && 'enum')
+	if (kind === 'enum')
 		return `${Object.keys(attributes).map(each => handlers(type, kind)[each](attributes[each])).join(' ')}`;
 
 	return '';

--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -76,6 +76,7 @@ const handlers = (type, kind) => {
 		relationOnDelete: value => {},
 		hasDefaultValue: value => {},
 		relationName: value => {},
+		documentation: value => {},
 		isReadOnly: value => {},
 		isGenerated: value => {},
 		isUpdatedAt: value => value ? '@updatedAt' : '',

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -40,6 +40,8 @@ function transformModel(model: Model) {
 			// Enum
 			if (kind === 'enum' && type !== singularizeModelName(type)) {
 				draftField.type = singularizeModelName(type);
+				if (draftField.default)
+					draftField.default = camelcase(draftField.default)
 			}
 
 			// Object kind, with @relation attributes


### PR DESCRIPTION
Given the following enum:

```
enum UserOnboardingStatus {
  onboarded
  twoFaSelection        @map("two-fa-selection")
  @@map("user_onboarding_status")
}
```

This PR modifies

```
model User {
  ...
  status     UserOnboardingStatus     @default(two_fa_selection)
  ...
}
```

into this (look at the value of the default)
```
model User {
  ...
  status     UserOnboardingStatus     @default(twoFaSelection)
  ...
}
```

therefore allowing Prisma to set the correct default value (otherwise there are compilation issues)